### PR TITLE
Emplementa a classe boleto como uma entidade JPA

### DIFF
--- a/src/main/java/com/tdesi/senai/pagamento/entity/Boleto.java
+++ b/src/main/java/com/tdesi/senai/pagamento/entity/Boleto.java
@@ -1,0 +1,78 @@
+package com.tdesi.senai.pagamento.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "boletos")
+public class Boleto {
+    
+    // Criação da tabela
+    @Id // define a variavel id como chave primaria
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // auto increment
+    private Long id;
+    private Long numero;
+    private String dataVencimento;
+    private Double multa;
+    private Double juros;
+
+    // Construtor pafrão (nescessario para entidades JPA)
+    public Boleto(Long numero, String dataVencimento) {
+        this.numero = numero;
+        this.dataVencimento = dataVencimento;
+    }
+
+    // Construtor completo
+    public Boleto(Long numero, String dataVencimento, Double multa, Double juros) {
+        this.numero = numero;
+        this.dataVencimento = dataVencimento;
+        this.multa = multa;
+        this.juros = juros;
+    }
+
+    // Getters and Setters
+
+    public Long getId() { 
+        return this.id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getNumero() { 
+        return this.numero;
+    }
+
+    public void setNumero(Long numero) {
+        this.numero = numero;
+    }
+
+    public String getDataVencimento() { 
+        return this.dataVencimento;
+    }
+
+    public void setDataVencimento(String dataVencimento) {
+        this.dataVencimento = dataVencimento;
+    }
+
+    public Double getMulta() { 
+        return this.multa;
+    }
+
+    public void setMulta(Double multa) {
+        this.multa = multa;
+    }
+
+    public Double getJuros() { 
+        return this.juros;
+    }
+
+    public void setJuros(Double juros) {
+        this.juros = juros;
+    }
+
+}

--- a/src/main/java/com/tdesi/senai/pagamento/entity/Pagamento.java
+++ b/src/main/java/com/tdesi/senai/pagamento/entity/Pagamento.java
@@ -43,7 +43,7 @@ public class Pagamento {
         return numero;
     }
 
-    public void setNumero(Long id) {
+    public void setNumero(Long numero) {
         this.numero = numero;
     }
 

--- a/src/main/java/com/tdesi/senai/pagamento/service/CartaoPagamentoService.java
+++ b/src/main/java/com/tdesi/senai/pagamento/service/CartaoPagamentoService.java
@@ -6,4 +6,4 @@ import org.springframework.stereotype.Service;
 public class CartaoPagamentoService {
     // Implementação dos métodos de serviço
 
-    }
+}


### PR DESCRIPTION
## Descrição
A classe Boletos foi implementada de acordo com os requerimentos. Foi usado o '@Entity' e o '@Table'. 
A classe está criando corretamente a sua tabela correspondente no banco de dados.

## Observações
Por não saber qual a variavel seria correta para adicionar datas no banco de dados, eu e o @arthurliszkievich, usamos String para definir datas nas classes JPA. No meu código foi a variavel 'dataVencimento'.

Eu também consertei um pequeno erro no código do @arthurliszkievich. O nome de uma variavel foi definida incorretamente. No código do @Rinchuu consertei a formatação.